### PR TITLE
添加SS_FORMAT_BYTE_BGRA后引起的改动。

### DIFF
--- a/src/format.h
+++ b/src/format.h
@@ -4,10 +4,10 @@
 
 inline size_t ss_render_format_ele_size(ss_render_format type){
 	static size_t values[] = {
-		0, 4, 4, 2
+		0, 4, 4, 2, 4
 	};
 	int iType = (int)type;
-	if (iType >= 0 && iType <= 3){
+	if (iType >= 0 && iType <= 4){
 		return values[iType];
 	}
 	return 0;
@@ -15,10 +15,10 @@ inline size_t ss_render_format_ele_size(ss_render_format type){
 
 inline int ss_render_format_ele_type(ss_render_format type){
 	static int values[] = {
-		0, GL_FLOAT, GL_UNSIGNED_BYTE, GL_FLOAT
+		0, GL_FLOAT, GL_UNSIGNED_BYTE, GL_FLOAT, GL_UNSIGNED_BYTE
 	};
 	int iType = (int)type;
-	if (iType >= 0 && iType <= 3){
+	if (iType >= 0 && iType <= 4){
 		return values[iType];
 	}
 	return 0;
@@ -37,10 +37,10 @@ inline GLboolean ss_render_format_normalized(ss_render_format type){
 
 inline int ss_render_format_format(ss_render_format type){
 	static GLint values[] = {
-		0, GL_RGBA, GL_RGBA
+		0, GL_RGBA, GL_RGBA, GL_RG, GL_BGRA
 	};
 	int iType = (int)type;
-	if (iType >= 0 && iType <= 2){
+	if (iType >= 0 && iType <= 4){
 		return values[iType];
 	}
 	return 0;

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -25,7 +25,7 @@ ss_texture2d* ss_gl_render_device::create_texture2d(
 	glBindTexture(GL_TEXTURE_2D, ret->name);
 
 	glTexImage2D(GL_TEXTURE_2D, 0,
-		ss_render_format_format(format),
+		/*ss_render_format_format(format)*/GL_RGBA,
 		width, height,
 		0,
 		ss_render_format_format(format),


### PR DESCRIPTION
texture.cpp中的那一处改动的动机是：感觉glTexImage2D的第三个参数: [ internalFormat ] 的可选余地较少，比如不支持GL_BGRA ，所以不如定死了，统一就是 GL_RGBA。
